### PR TITLE
Added Roadmap link of DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,5 +221,5 @@ Check out the [Contributing Guidelines](https://github.com/TheRemoteLab/awesome-
 
 ## Roadmap:
 
-- [DevOps Roadmap](https://roadmap.sh/devops)
+- [ ] [DevOps Roadmap](https://roadmap.sh/devops)
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
 
 
 * [Conferences and Meet-ups](#conferences) :video_camera:
-
 * [Contributing](#contributing)
 * [License](#license)
+* [Roadmap](#roadmap)
 
 ## Philosophy
 
@@ -218,3 +218,8 @@ Check out the [Contributing Guidelines](https://github.com/TheRemoteLab/awesome-
 ## License:
 
   <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/InteractiveResource" property="dct:title" rel="dct:type">awesome-learning</span> by <a xmlns:cc="http://creativecommons.org" href="http://www.linkedin.com/company/the-remote-lab" property="cc:attributionName" rel="cc:attributionURL">The Remote Lab</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.
+
+## Roadmap:
+
+- [DevOps Roadmap](https://roadmap.sh/devops)
+


### PR DESCRIPTION
Hi Ramit,

I came across your repository [awesome-learning](https://github.com/Lets-DevOps/awesome-learning) and found it to be a valuable resource for DevOps enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["DevOps Roadmap"](https://roadmap.sh/devops). I took the initiative to submit a ["Pull Request"](https://github.com/Lets-DevOps/awesome-learning/pull/39) adding it in the roadmap section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz